### PR TITLE
Fix PyPI README.MD showing problem.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     keywords = 'django heroku cloud postgresql postgres db database awesome epic',
     description = 'Automatic Django database configuration on Heroku.',
     long_description = open(normpath(join(dirname(abspath(__file__)),
-        'README.md'))).read()
+        'README.md'))).read(),
+    long_description_content_type='text/markdown'
 
 )


### PR DESCRIPTION
There is a problem in the project's PyPI page. To fix this I added the following line in the setup.py file:
```python
long_description_content_type='text/markdown'
```